### PR TITLE
Colored reacher task + python XML generation

### DIFF
--- a/experiments/reacher_color/hyperparams.py
+++ b/experiments/reacher_color/hyperparams.py
@@ -1,0 +1,218 @@
+from __future__ import division
+
+from datetime import datetime
+import os.path
+import numpy as np
+import operator
+
+from gps import __file__ as gps_filepath
+from gps.agent.mjc import AgentMuJoCo, colored_reacher
+from gps.algorithm.algorithm_badmm import AlgorithmBADMM
+from gps.algorithm.algorithm_traj_opt import AlgorithmTrajOpt
+from gps.algorithm.algorithm_mdgps import AlgorithmMDGPS
+from gps.algorithm.cost.cost_action import CostAction
+from gps.algorithm.cost.cost_state import CostState
+from gps.algorithm.cost.cost_fk import CostFK
+from gps.algorithm.cost.cost_sum import CostSum
+#from gps.algorithm.cost.cost_gym import CostGym
+from gps.algorithm.dynamics.dynamics_lr_prior import DynamicsLRPrior
+from gps.algorithm.dynamics.dynamics_prior_gmm import DynamicsPriorGMM
+from gps.algorithm.traj_opt.traj_opt_lqr_python import TrajOptLQRPython
+from gps.algorithm.policy.lin_gauss_init import init_lqr, init_pd
+from gps.algorithm.policy_opt.policy_opt_caffe import PolicyOptCaffe
+from gps.algorithm.policy.policy_prior_gmm import PolicyPriorGMM
+from gps.algorithm.cost.cost_utils import RAMP_LINEAR, RAMP_FINAL_ONLY, RAMP_QUADRATIC, evall1l2term
+from gps.utility.data_logger import DataLogger
+
+from gps.proto.gps_pb2 import JOINT_ANGLES, JOINT_VELOCITIES, \
+        END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES, RGB_IMAGE, RGB_IMAGE_SIZE, ACTION
+from gps.gui.config import generate_experiment_info
+
+SENSOR_DIMS = {
+    JOINT_ANGLES: 2,
+    JOINT_VELOCITIES: 2,
+    END_EFFECTOR_POINTS: 6,
+    END_EFFECTOR_POINT_VELOCITIES: 6,
+    ACTION: 2,
+}
+
+BASE_DIR = '/'.join(str.split(__file__, '/')[:-2])
+EXP_DIR = '/'.join(str.split(__file__, '/')[:-1]) + '/'
+
+
+np.random.seed(47)
+CONDITIONS = 3
+pos_body_offset = []
+#pos_body_offset.append(np.array([-0.1, 0.2, 0.0]))
+#pos_body_offset.append(np.array([0.05, 0.2, 0.0]))
+for _ in range(CONDITIONS):
+    pos_body_offset.append(np.array([0.4*np.random.rand()-0.3, 0.4*np.random.rand()-0.1 ,0]))
+
+common = {
+    'experiment_name': 'my_experiment' + '_' + \
+            datetime.strftime(datetime.now(), '%m-%d-%y_%H-%M'),
+    'experiment_dir': EXP_DIR,
+    'data_files_dir': EXP_DIR + 'data_files/',
+    'target_filename': EXP_DIR + 'target.npz',
+    'log_filename': EXP_DIR + 'log.txt',
+    'conditions': CONDITIONS,
+}
+
+if not os.path.exists(common['data_files_dir']):
+    os.makedirs(common['data_files_dir'])
+
+agent = {
+    'type': AgentMuJoCo,
+    #'filename': './mjc_models/reacher_img.xml',
+    'models': [colored_reacher(target_color='red'), colored_reacher(target_color='green'), colored_reacher(target_color='yellow')],
+    'x0': np.zeros(4),
+    'dt': 0.05,
+    'substeps': 5,
+    'pos_body_offset': pos_body_offset,
+    'pos_body_idx': np.array([4]),
+    'conditions': common['conditions'],
+    'T': 50,
+    'sensor_dims': SENSOR_DIMS,
+    'state_include': [JOINT_ANGLES, JOINT_VELOCITIES, \
+            END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'obs_include': [JOINT_ANGLES, JOINT_VELOCITIES, \
+            END_EFFECTOR_POINTS, END_EFFECTOR_POINT_VELOCITIES],
+    'meta_include': [],
+    'camera_pos': np.array([0., 0., 3., 0., 0., 0.]),
+    'target_end_effector': [np.concatenate([np.array([.1, -.1, .01])+ pos_body_offset[i], np.array([0., 0., 0.])])
+                            for i in xrange(CONDITIONS)],
+}
+
+algorithm = {
+    'type': AlgorithmTrajOpt,
+    'max_ent_traj': 0.001,
+    'conditions': common['conditions'],
+    'iterations': 15,
+    'step_rule': 'classic',
+    'plot_dir': EXP_DIR,
+    'agent_x0': agent['x0'],
+    'agent_pos_body_idx': agent['pos_body_idx'],
+    'agent_pos_body_offset': agent['pos_body_offset'],
+    'target_end_effector': [np.concatenate([np.array([.1, -.1, .01])+ agent['pos_body_offset'][i], np.array([0., 0., 0.])])
+                            for i in xrange(CONDITIONS)],
+}
+
+
+#algorithm = {
+#    'type': AlgorithmMDGPS,
+#    'sample_on_policy': True,
+#    'conditions': common['conditions'],
+#    'train_conditions': common['train_conditions'],
+#    'test_conditions': common['test_conditions'],
+#    'iterations': 10,
+#    'kl_step': 1.0,
+#    'min_step_mult': 0.2,
+#    'max_step_mult': 2.0,
+#    'policy_sample_mode': 'replace',
+#}
+
+PR2_GAINS = np.array([1.0, 1.0])
+torque_cost_1 = [{
+    'type': CostAction,
+    'wu': 1 / PR2_GAINS,
+} for i in range(common['conditions'])]
+
+fk_cost_1 = [{
+    'type': CostFK,
+    'target_end_effector': np.concatenate([np.array([.1, -.1, .01])+ agent['pos_body_offset'][i], np.array([0., 0., 0.])]),
+    'wp': np.array([1, 1, 1, 0, 0, 0]),
+    'l1': 0.1,
+    'l2': 10.0,
+    'alpha': 1e-5,
+    'evalnorm': evall1l2term,
+} for i in range(common['conditions'])]
+
+algorithm['cost'] = [{
+    'type': CostSum,
+    'costs': [torque_cost_1[i], fk_cost_1[i]],
+    'weights': [2.0, 1.0],
+    'evalnorm': evall1l2term,
+}  for i in range(common['conditions'])]
+
+
+# Cost function
+#torque_cost = {
+    #'type': CostAction,
+    #'wu': np.ones(2),
+#}
+
+
+#state_cost = {
+    #'type': CostState,
+    #'data_types': [END_EFFECTOR_POINTS],
+    #'A' : np.c_[np.eye(3), -np.eye(3)],
+    #'l1': 1.0,
+    #'l2': 0.0,
+    #'alpha': 0.0,
+    #'evalnorm': evall1l2term,
+#}
+
+#algorithm['cost'] = {
+    #'type': CostSum,
+    #'costs': [torque_cost, state_cost],
+    #'weights': [2.0, 1.0],
+#}
+
+#algorithm['cost'] = {
+#    'type': CostGym,
+#}
+
+#algorithm['policy_opt'] = {
+#    'type': PolicyOptCaffe,
+#    'iterations': 5000,
+#    'weights_file_prefix': common['data_files_dir'] + 'policy',
+#}
+
+algorithm['init_traj_distr'] = {
+    'type': init_lqr,
+    'init_gains':  100.0 * np.ones(SENSOR_DIMS[ACTION]),
+    'init_acc': np.zeros(SENSOR_DIMS[ACTION]),
+    'init_var': 1.0,
+    'dt': agent['dt'],
+    'T': agent['T'],
+}
+
+algorithm['dynamics'] = {
+    'type': DynamicsLRPrior,
+    'regularization': 1e-6,
+    'prior': {
+        'type': DynamicsPriorGMM,
+        'max_clusters': 30,
+        'min_samples_per_cluster': 40,
+        'max_samples': 10, #len(common['train_conditions']),
+    },
+}
+
+algorithm['traj_opt'] = {
+    'type': TrajOptLQRPython,
+    'min_eta': 1e-4,
+    'max_eta': 1.0,
+}
+
+
+algorithm['policy_prior'] = {
+    'type': PolicyPriorGMM,
+    'max_clusters': 40,
+    'min_samples_per_cluster': 40,
+}
+
+
+config = {
+    'iterations': algorithm['iterations'],
+    'num_samples': 5,
+    'verbose_trials': 1,
+    'verbose_policy_trials': 0,
+    'common': common,
+    'agent': agent,
+    'gui_on': True,
+    'algorithm': algorithm,
+    'conditions': common['conditions'],
+    'random_seed': 1,
+}
+
+common['info'] = generate_experiment_info(config)

--- a/python/gps/agent/config.py
+++ b/python/gps/agent/config.py
@@ -75,6 +75,7 @@ AGENT_MUJOCO = {
     'randomly_sample_bodypos': False,
     'record_reward': False,
     'render': False, # for EC2
+    'filename': None,
 }
 
 AGENT_BOX2D = {

--- a/python/gps/agent/mjc/__init__.py
+++ b/python/gps/agent/mjc/__init__.py
@@ -1,0 +1,3 @@
+from model_builder import *
+from agent_mjc import *
+from mjc_models import *

--- a/python/gps/agent/mjc/agent_mjc.py
+++ b/python/gps/agent/mjc/agent_mjc.py
@@ -27,7 +27,13 @@ class AgentMuJoCo(Agent):
         config.update(hyperparams)
         Agent.__init__(self, config)
         self._setup_conditions()
-        self._setup_world(hyperparams['filename'])
+        if 'models' in hyperparams:
+            # If MJCModel objects are provided, load those instead
+            files = [model.open() for model in hyperparams['models']]
+            self._setup_world([f.name for f in files])
+            [f.close() for f in files]
+        else:
+            self._setup_world(hyperparams['filename'])
 
     def _setup_conditions(self):
         """
@@ -57,7 +63,7 @@ class AgentMuJoCo(Agent):
                            for i in range(self._hyperparams['conditions'])]
         else:
             for i in range(self._hyperparams['conditions']):
-                self._world.append(mjcpy.MJCWorld(self._hyperparams['filename'][i]))
+                self._world.append(mjcpy.MJCWorld(filename[i]))
                 self._model.append(self._world[i].get_model())
 
         for i in range(self._hyperparams['conditions']):

--- a/python/gps/agent/mjc/mjc_models.py
+++ b/python/gps/agent/mjc/mjc_models.py
@@ -1,0 +1,100 @@
+import numpy as np
+
+from gps.agent.mjc.model_builder import default_model
+
+
+COLOR_MAP = {
+    'red': [1, 0, 0, 1],
+    'green': [0, 1, 0, 1],
+    'blue': [0, 0, 1, 1],
+    'white': [1, 1, 1, 1],
+    'yellow': [1, 1, 0, 1],
+    'purple': [1, 0, 1, 1],
+    'cyan': [0, 1, 1, 1],
+}
+
+def reacher():
+    """
+    An example usage of MJCModel building the reacher task
+
+    Returns:
+        An MJCModel
+    """
+    mjcmodel = default_model('reacher')
+    worldbody = mjcmodel.root.worldbody()
+
+    # Arena
+    worldbody.geom(conaffinity="0",fromto="-.3 -.3 .01 .3 -.3 .01",name="sideS",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+    worldbody.geom(conaffinity="0",fromto=" .3 -.3 .01 .3  .3 .01",name="sideE",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+    worldbody.geom(conaffinity="0",fromto="-.3  .3 .01 .3  .3 .01",name="sideN",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+    worldbody.geom(conaffinity="0",fromto="-.3 -.3 .01 -.3 .3 .01",name="sideW",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+
+    # Arm
+    worldbody.geom(conaffinity="0",contype="0",fromto="0 0 0 0 0 0.02",name="root",rgba="0.9 0.4 0.6 1",size=".011",type="cylinder")
+    body = worldbody.body(name="body0", pos="0 0 .01")
+    body.geom(fromto="0 0 0 0.1 0 0",name="link0",rgba="0.0 0.4 0.6 1",size=".01",type="capsule")
+    body.joint(axis="0 0 1",limited="false",name="joint0",pos="0 0 0",type="hinge")
+    body = body.body(name="body1",pos="0.1 0 0")
+    body.joint(axis="0 0 1",limited="true",name="joint1",pos="0 0 0",range="-3.0 3.0",type="hinge")
+    body.geom(fromto="0 0 0 0.1 0 0",name="link1",rgba="0.0 0.4 0.6 1",size=".01",type="capsule")
+    body = body.body(name="fingertip",pos="0.11 0 0")
+    body.site(name="fingertip",pos="0 0 0",size="0.01")
+    body.geom(contype="0",name="fingertip",pos="0 0 0",rgba="0.0 0.8 0.6 1",size=".01",type="sphere")
+
+    # Target
+    body = worldbody.body(name="target",pos=".1 -.1 .01")
+    body.geom(rgba="1. 0. 0. 1",type="box",size="0.01 0.01 0.01",density='0.00001',contype="0",conaffinity="0")
+    body.site(name="target",pos="0 0 0",size="0.01")
+
+    # Actuators
+    actuator = mjcmodel.root.actuator()
+    actuator.motor(ctrllimited="true",ctrlrange="-1.0 1.0",gear="200.0",joint="joint0")
+    actuator.motor(ctrllimited="true",ctrlrange="-1.0 1.0",gear="200.0",joint="joint1")
+
+    return mjcmodel
+
+
+def colored_reacher(ncubes=6, target_color="red", cube_size=0.015):
+    mjcmodel = default_model('reacher')
+    worldbody = mjcmodel.root.worldbody()
+
+    # Arena
+    worldbody.geom(conaffinity="0",fromto="-.3 -.3 .01 .3 -.3 .01",name="sideS",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+    worldbody.geom(conaffinity="0",fromto=" .3 -.3 .01 .3  .3 .01",name="sideE",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+    worldbody.geom(conaffinity="0",fromto="-.3  .3 .01 .3  .3 .01",name="sideN",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+    worldbody.geom(conaffinity="0",fromto="-.3 -.3 .01 -.3 .3 .01",name="sideW",rgba="0.9 0.4 0.6 1",size=".02",type="capsule")
+
+    # Arm
+    worldbody.geom(conaffinity="0",contype="0",fromto="0 0 0 0 0 0.02",name="root",rgba="0.9 0.4 0.6 1",size=".011",type="cylinder")
+    body = worldbody.body(name="body0", pos="0 0 .01")
+    body.geom(fromto="0 0 0 0.1 0 0",name="link0",rgba="0.0 0.4 0.6 1",size=".01",type="capsule")
+    body.joint(axis="0 0 1",limited="false",name="joint0",pos="0 0 0",type="hinge")
+    body = body.body(name="body1",pos="0.1 0 0")
+    body.joint(axis="0 0 1",limited="true",name="joint1",pos="0 0 0",range="-3.0 3.0",type="hinge")
+    body.geom(fromto="0 0 0 0.1 0 0",name="link1",rgba="0.0 0.4 0.6 1",size=".01",type="capsule")
+    body = body.body(name="fingertip",pos="0.11 0 0")
+    body.site(name="fingertip",pos="0 0 0",size="0.01")
+    body.geom(contype="0",name="fingertip",pos="0 0 0",rgba=COLOR_MAP[target_color],size=".01",type="sphere")
+
+    # Target
+    body = worldbody.body(name="target",pos=".1 -.1 .01")
+    body.geom(rgba=COLOR_MAP[target_color],type="box",size=cube_size*np.ones(3),density='0.00001',contype="0",conaffinity="0")
+    body.site(name="target",pos="0 0 0",size="0.01")
+
+    # Distractor cubes
+    available_colors = COLOR_MAP.keys()
+    available_colors.remove(target_color)
+    for i in range(ncubes-1):
+        pos = np.random.rand(3)
+        pos = pos*0.5-0.25
+        pos[2] = 0.01
+        body = worldbody.body(name="cube_%d"%i,pos=pos)
+
+        color = np.random.choice(available_colors)
+        body.geom(rgba=COLOR_MAP[color],type="box",size=cube_size*np.ones(3),density='0.00001',contype="0",conaffinity="0")
+
+    # Actuators
+    actuator = mjcmodel.root.actuator()
+    actuator.motor(ctrllimited="true",ctrlrange="-1.0 1.0",gear="200.0",joint="joint0")
+    actuator.motor(ctrllimited="true",ctrlrange="-1.0 1.0",gear="200.0",joint="joint1")
+    return mjcmodel

--- a/python/gps/agent/mjc/model_builder.py
+++ b/python/gps/agent/mjc/model_builder.py
@@ -1,0 +1,108 @@
+"""
+model_builder.py
+
+A small library for programatically building MuJoCo XML files
+
+"""
+from contextlib import contextmanager
+import tempfile
+import numpy as np
+
+
+def default_model(name):
+    """
+    Get a model with basic settings such as gravity and RK4 integration enabled
+    """
+    model = MJCModel(name)
+    root = model.root
+
+    # Setup
+    root.compiler(angle="radian", inertiafromgeom="true")
+    default = root.default()
+    default.joint(armature=1, damping=1, limited="true")
+    default.geom(contype=0, friction='1 0.1 0.1', rgba='0.7 0.7 0 1')
+    root.option(gravity="0 0 -9.81", integrator="RK4", timestep=0.01)
+    return model
+
+
+class MJCModel(object):
+    def __init__(self, name):
+        self.name = name
+        self.root = MJCTreeNode("mujoco").add_attr('model', name)
+
+    @contextmanager
+    def asfile(self):
+        """
+        Usage:
+
+        model = MJCModel('reacher')
+        with model.asfile() as f:
+            print f.read()  # prints a dump of the model
+
+        """
+        with tempfile.NamedTemporaryFile(mode='w+b', suffix='.xml') as f:
+            self.root.write(f)
+            f.seek(0)
+            yield f
+
+    def open(self):
+        self.file = tempfile.NamedTemporaryFile(mode='w+b', suffix='.xml')
+        self.root.write(self.file)
+        self.file.seek(0)
+        return self.file
+
+    def close(self):
+        self.file.close()
+
+
+class MJCTreeNode(object):
+    def __init__(self, name):
+        self.name = name
+        self.attrs = {}
+        self.children = []
+
+    def add_attr(self, key, value):
+        if isinstance(value, basestring):
+            pass
+        elif isinstance(value, list) or isinstance(value, np.ndarray):
+            value = ' '.join([str(val) for val in value])
+
+        self.attrs[key] = value
+        return self
+
+    def __getattr__(self, name):
+        def wrapper(**kwargs):
+            newnode =  MJCTreeNode(name)
+            for (k, v) in kwargs.iteritems():
+                newnode.add_attr(k, v)
+            self.children.append(newnode)
+            return newnode
+        return wrapper
+
+    def dfs(self):
+        yield self
+        if self.children:
+            for child in self.children:
+                for node in child.dfs():
+                    yield node
+
+    def write(self, ostream, tabs=0):
+        contents = ' '.join(['%s="%s"'%(k,v) for (k,v) in self.attrs.iteritems()])
+        if self.children:
+
+            ostream.write('\t'*tabs)
+            ostream.write('<%s %s>\n' % (self.name, contents))
+            for child in self.children:
+                child.write(ostream, tabs=tabs+1)
+            ostream.write('\t'*tabs)
+            ostream.write('</%s>\n' % self.name)
+        else:
+            ostream.write('\t'*tabs)
+            ostream.write('<%s %s/>\n' % (self.name, contents))
+
+    def __str__(self):
+        s = "<"+self.name
+        s += ' '.join(['%s="%s"'%(k,v) for (k,v) in self.attrs.iteritems()])
+        return s+">"
+
+

--- a/python/gps/gps_main.py
+++ b/python/gps/gps_main.py
@@ -581,6 +581,7 @@ def main():
         compare_experiments(mean_dists_1_dict, mean_dists_2_dict, success_rates_1_dict, \
                                 success_rates_2_dict)
     else:
+        gps = GPSMain(hyperparams.config)
         if hyperparams.config['gui_on']:
             run_gps = threading.Thread(
                 target=lambda: gps.run(itr_load=resume_training_itr)


### PR DESCRIPTION
- Added a system for writing MuJoCo XML files in python, so they can be programatically manipulated. Instead of specifying a filename to AgentMJC, specify a "models" parameter, which is a list of MJCModel objects that are built in python. (The new models are defined in the mjc_models.py file)
  - For example, in the new reacher task:
  
  ```
  agent = {
  'models': [colored_reacher(target_color='red'), colored_reacher(target_color='green'), colored_reacher(target_color='yellow')]
  ...
  }
  ```
- Added a colored reacher task. The color of the tip of the reacher matches the color of a single target block. There are a configurable number of random distractor blocks which do not share a color with the target.

Green reacher:
![screenshot from 2016-09-21 20-28-22](https://cloud.githubusercontent.com/assets/5401540/18736293/77b8f7ee-803a-11e6-9863-12893031b93e.png)

Red reacher:
![screenshot from 2016-09-21 20-28-05](https://cloud.githubusercontent.com/assets/5401540/18736294/797d50de-803a-11e6-86a9-130197bf8570.png)
